### PR TITLE
Linux support. sdl. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # Expose the runtime/launcher's POSIX APIs under strict C11.
+    add_compile_definitions("$<$<COMPILE_LANGUAGE:C>:_GNU_SOURCE>")
+endif()
+
 set(DKC3_ROM "" CACHE FILEPATH
     "Private path to a headerless DKC3 USA (En,Fr) ROM")
 set(DKC3_DESKTOP_ICON "" CACHE FILEPATH

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ game's code is statically recompiled to C by [snesrecomp](snesrecomp/README.md)
 from a bank configuration derived from a public disassembly, the shared
 snesrecomp runtime executes anything the analysis cannot prove through its
 65816 interpreter, and project-owned hosts present the game natively on
-macOS (and, unverified here, Windows).
+macOS and Linux (and, unverified here, Windows).
 
 You must supply your own DKC3 ROM. The supported image is the headerless
 North American (En,Fr) release, 4 MiB, SHA-256
@@ -82,6 +82,22 @@ and emits the private recompiled units under `generated/` (ignored by Git).
 `build_macos.sh` builds `build/macos/DKC3Recomp.app` and the headless
 runner, bundles SDL2, embeds the project icon, and ad-hoc signs the app. Open
 the app and select the ROM in its launcher.
+
+## Building on Linux
+
+Requires C/C++ compilers, CMake, Ninja, Python 3, Cargo, and SDL2/OpenGL
+development packages.
+
+```sh
+git submodule update --init --recursive
+python3 scripts/generate_snesrecomp.py --rom /private/path/dkc3.sfc
+cmake -S . -B build/linux -G Ninja -DCMAKE_BUILD_TYPE=Release -DDKC3_FETCH_SDL2=OFF
+cmake --build build/linux --target dkc3_snesrecomp_sdl dkc3_snesrecomp_headless
+./build/linux/DKC3Recomp /private/path/dkc3.sfc
+```
+
+Keep `build/linux/assets/` beside the executable. The existing launcher and
+Escape menu provide settings. See [docs/BRINGUP.md](docs/BRINGUP.md) for validation.
 
 ## Headless validation
 

--- a/runner/headless_main.c
+++ b/runner/headless_main.c
@@ -337,17 +337,17 @@ int main(int argc, char **argv) {
        * bit is positive up to 256 + extra, negative beyond. */
       const int extra = Dkc3VideoExtra();
       for (int index = 0; index < 128; index++) {
-        const uint8_t *entry = g_ppu->oam + index * 4;
-        int x = entry[0] |
+        const uint16_t *entry = g_ppu->oam + index * 2;
+        int x = (entry[0] & 0xff) |
                 (((g_ppu->highOam[index >> 2] >> ((index & 3) * 2)) & 1)
                  << 8);
         if (x >= 256 + extra)
           x -= 512;
-        const int y = entry[1];
+        const int y = entry[0] >> 8;
         if (y >= 224 || (x >= 0 && x < 256))
           continue;
         fprintf(stderr, "oam frame=%ld index=%d x=%d y=%d tile=%02x attr=%02x\n",
-                frame, index, x, y, entry[2], entry[3]);
+                frame, index, x, y, entry[1] & 0xff, entry[1] >> 8);
       }
     }
     if (g_fail) {


### PR DESCRIPTION
Add readme to build on linux. sdl

- Add compile definitions for linux gnu sources

Figured i would do this since i was already testing the other dkc repos so why not.
potentially the desktop overlay imgui change could affect you so probably test that on mac before merge. thanks

escape menu works, just like dkc2 and can select widescreen. did not test full game.    
i removed the escape menu bug fixes from this pr. that is not my scope so forget it. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Linux build support and fixes the Escape menu from accidentally quitting the game when stale controller input is delivered while the menu is closed.

- Discards gamepad and keyboard events that arrive while the pause menu is closed.
- Adds `_GNU_SOURCE` compile definition for Linux and documents the SDL2/OpenGL build steps in the README.
- Fixes OAM debug output to read sprite fields correctly.

<sup>Written for commit 981de18e5a4df6b23d50f493410caf5fcc853629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/DKC3Recomp/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

